### PR TITLE
refactor: thorgen event filterin

### DIFF
--- a/accounts/contract.go
+++ b/accounts/contract.go
@@ -171,7 +171,7 @@ func (c *Contract) EventCriteria(name string, matchers ...interface{}) (thorest.
 type Event struct {
 	Name string
 	Args map[string]interface{}
-	Log  thorest.EventLog
+	Log  *thorest.EventLog
 }
 
 // DecodeEvents parses logs into a slice of decoded events.
@@ -194,7 +194,7 @@ type Event struct {
 //	}
 //
 // This function returns a slice of decoded event objects and any error encountered.
-func (c *Contract) DecodeEvents(logs []thorest.EventLog) ([]Event, error) {
+func (c *Contract) DecodeEvents(logs []*thorest.EventLog) ([]Event, error) {
 	var decoded []Event
 	for _, log := range logs {
 		if len(log.Topics) < 2 {
@@ -234,7 +234,7 @@ func (c *Contract) DecodeEvents(logs []thorest.EventLog) ([]Event, error) {
 }
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
-func (c *Contract) UnpackLog(out interface{}, event string, log thorest.EventLog) error {
+func (c *Contract) UnpackLog(out interface{}, event string, log *thorest.EventLog) error {
 	if len(log.Topics) == 0 {
 		return errors.New("anonymous events are not supported")
 	}

--- a/builtins/executor.go
+++ b/builtins/executor.go
@@ -363,7 +363,7 @@ func (_Executor *Executor) RevokeApproverAsClause(_approver common.Address, vetV
 type ExecutorApprover struct {
 	Approver common.Address
 	Action   [32]byte
-	Log      thorest.EventLog
+	Log      *thorest.EventLog
 }
 
 type ExecutorApproverCriteria struct {
@@ -404,14 +404,6 @@ func (_Executor *Executor) FilterApprover(criteria []ExecutorApproverCriteria, f
 	logs, err := _Executor.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _Executor.contract.ABI.Events["Approver"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]ExecutorApprover, len(logs))
@@ -466,42 +458,14 @@ func (_Executor *Executor) WatchApprover(criteria []ExecutorApproverCriteria, ct
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_Executor.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(ExecutorApprover)
-							if err := _Executor.contract.UnpackLog(ev, "Approver", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(ExecutorApprover)
+					if err := _Executor.contract.UnpackLog(ev, "Approver", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return
@@ -516,7 +480,7 @@ func (_Executor *Executor) WatchApprover(criteria []ExecutorApproverCriteria, ct
 type ExecutorProposal struct {
 	ProposalID [32]byte
 	Action     [32]byte
-	Log        thorest.EventLog
+	Log        *thorest.EventLog
 }
 
 type ExecutorProposalCriteria struct {
@@ -557,14 +521,6 @@ func (_Executor *Executor) FilterProposal(criteria []ExecutorProposalCriteria, f
 	logs, err := _Executor.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _Executor.contract.ABI.Events["Proposal"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]ExecutorProposal, len(logs))
@@ -619,42 +575,14 @@ func (_Executor *Executor) WatchProposal(criteria []ExecutorProposalCriteria, ct
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_Executor.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(ExecutorProposal)
-							if err := _Executor.contract.UnpackLog(ev, "Proposal", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(ExecutorProposal)
+					if err := _Executor.contract.UnpackLog(ev, "Proposal", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return
@@ -669,7 +597,7 @@ func (_Executor *Executor) WatchProposal(criteria []ExecutorProposalCriteria, ct
 type ExecutorVotingContract struct {
 	ContractAddr common.Address
 	Action       [32]byte
-	Log          thorest.EventLog
+	Log          *thorest.EventLog
 }
 
 type ExecutorVotingContractCriteria struct {
@@ -710,14 +638,6 @@ func (_Executor *Executor) FilterVotingContract(criteria []ExecutorVotingContrac
 	logs, err := _Executor.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _Executor.contract.ABI.Events["VotingContract"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]ExecutorVotingContract, len(logs))
@@ -772,42 +692,14 @@ func (_Executor *Executor) WatchVotingContract(criteria []ExecutorVotingContract
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_Executor.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(ExecutorVotingContract)
-							if err := _Executor.contract.UnpackLog(ev, "VotingContract", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(ExecutorVotingContract)
+					if err := _Executor.contract.UnpackLog(ev, "VotingContract", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return

--- a/builtins/vtho.go
+++ b/builtins/vtho.go
@@ -340,7 +340,7 @@ type VTHOApproval struct {
 	Owner   common.Address
 	Spender common.Address
 	Value   *big.Int
-	Log     thorest.EventLog
+	Log     *thorest.EventLog
 }
 
 type VTHOApprovalCriteria struct {
@@ -390,14 +390,6 @@ func (_VTHO *VTHO) FilterApproval(criteria []VTHOApprovalCriteria, filters *thor
 	logs, err := _VTHO.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _VTHO.contract.ABI.Events["Approval"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]VTHOApproval, len(logs))
@@ -460,42 +452,14 @@ func (_VTHO *VTHO) WatchApproval(criteria []VTHOApprovalCriteria, ctx context.Co
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_VTHO.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(VTHOApproval)
-							if err := _VTHO.contract.UnpackLog(ev, "Approval", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(VTHOApproval)
+					if err := _VTHO.contract.UnpackLog(ev, "Approval", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return
@@ -511,7 +475,7 @@ type VTHOTransfer struct {
 	From  common.Address
 	To    common.Address
 	Value *big.Int
-	Log   thorest.EventLog
+	Log   *thorest.EventLog
 }
 
 type VTHOTransferCriteria struct {
@@ -561,14 +525,6 @@ func (_VTHO *VTHO) FilterTransfer(criteria []VTHOTransferCriteria, filters *thor
 	logs, err := _VTHO.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _VTHO.contract.ABI.Events["Transfer"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]VTHOTransfer, len(logs))
@@ -631,42 +587,14 @@ func (_VTHO *VTHO) WatchTransfer(criteria []VTHOTransferCriteria, ctx context.Co
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_VTHO.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(VTHOTransfer)
-							if err := _VTHO.contract.UnpackLog(ev, "Transfer", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(VTHOTransfer)
+					if err := _VTHO.contract.UnpackLog(ev, "Transfer", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return

--- a/cmd/thorgen/thorgen_test.go
+++ b/cmd/thorgen/thorgen_test.go
@@ -1,0 +1,118 @@
+package main_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/darrenvechain/thorgo/internal/testcontainer"
+	"github.com/darrenvechain/thorgo/internal/testcontract"
+	"github.com/darrenvechain/thorgo/solo"
+	"github.com/darrenvechain/thorgo/thorest"
+	"github.com/darrenvechain/thorgo/transactions"
+	"github.com/darrenvechain/thorgo/txmanager"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client, cancel = testcontainer.NewSolo()
+)
+
+func deployErc20(client *thorest.Client, txsender *txmanager.PKManager) (common.Hash, *testcontract.Erc20Transactor, error) {
+	return testcontract.DeployErc20(context.Background(), client, txsender, &transactions.Options{}, "TestToken", "TT")
+}
+
+func TestMain(m *testing.M) {
+	m.Run()
+	cancel()
+}
+
+func TestDeploy(t *testing.T) {
+	txsender := txmanager.FromPK(solo.Keys()[0], client)
+
+	_, _, err := deployErc20(client, txsender)
+	assert.NoError(t, err)
+}
+
+func TestCall(t *testing.T) {
+	txsender := txmanager.FromPK(solo.Keys()[0], client)
+
+	_, erc20, err := deployErc20(client, txsender)
+	assert.NoError(t, err)
+
+	supply, err := erc20.TotalSupply()
+	assert.NoError(t, err)
+
+	assert.True(t, supply.Cmp(big.NewInt(0)) == 0)
+}
+
+func TestTransactor(t *testing.T) {
+	txsender := txmanager.FromPK(solo.Keys()[0], client)
+	receiver := txmanager.FromPK(solo.Keys()[1], client)
+
+	_, erc20, err := deployErc20(client, txsender)
+	assert.NoError(t, err)
+
+	tx, err := erc20.Mint(receiver.Address(), big.NewInt(1000), &transactions.Options{})
+	assert.NoError(t, err)
+	receipt, err := tx.Wait(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, receipt)
+
+	supply, err := erc20.TotalSupply()
+	assert.NoError(t, err)
+
+	assert.True(t, supply.Cmp(big.NewInt(1000)) == 0)
+}
+
+func TestFilter(t *testing.T) {
+	txsender := txmanager.FromPK(solo.Keys()[0], client)
+	receiver := txmanager.FromPK(solo.Keys()[1], client)
+
+	_, erc20, err := deployErc20(client, txsender)
+	assert.NoError(t, err)
+
+	tx, err := erc20.Mint(receiver.Address(), big.NewInt(1000), &transactions.Options{})
+	assert.NoError(t, err)
+	receipt, err := tx.Wait(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, receipt)
+
+	events, err := erc20.FilterTransfer(make([]testcontract.Erc20TransferCriteria, 0), nil)
+	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+	assert.Equal(t, common.Address{}, events[0].From)
+	assert.Equal(t, receiver.Address(), events[0].To)
+	assert.True(t, events[0].Value.Cmp(big.NewInt(1000)) == 0)
+}
+
+func TestWatch(t *testing.T) {
+	txsender := txmanager.FromPK(solo.Keys()[0], client)
+	receiver := txmanager.FromPK(solo.Keys()[1], client)
+
+	_, erc20, err := deployErc20(client, txsender)
+	assert.NoError(t, err)
+
+	timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	eventChan, err := erc20.WatchTransfer(make([]testcontract.Erc20TransferCriteria, 0), timeout, 10)
+	assert.NoError(t, err)
+
+	tx, err := erc20.Mint(receiver.Address(), big.NewInt(1000), &transactions.Options{})
+	assert.NoError(t, err)
+	receipt, err := tx.Wait(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, receipt)
+
+	select {
+	case event := <-eventChan:
+		assert.Equal(t, common.Address{}, event.From)
+		assert.Equal(t, receiver.Address(), event.To)
+		assert.True(t, event.Value.Cmp(big.NewInt(1000)) == 0)
+	case <-timeout.Done():
+		assert.Fail(t, "timeout")
+	}
+}

--- a/internal/testcontract/erc20.go
+++ b/internal/testcontract/erc20.go
@@ -379,7 +379,7 @@ type Erc20Approval struct {
 	Owner   common.Address
 	Spender common.Address
 	Value   *big.Int
-	Log     thorest.EventLog
+	Log     *thorest.EventLog
 }
 
 type Erc20ApprovalCriteria struct {
@@ -429,14 +429,6 @@ func (_Erc20 *Erc20) FilterApproval(criteria []Erc20ApprovalCriteria, filters *t
 	logs, err := _Erc20.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _Erc20.contract.ABI.Events["Approval"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]Erc20Approval, len(logs))
@@ -499,42 +491,14 @@ func (_Erc20 *Erc20) WatchApproval(criteria []Erc20ApprovalCriteria, ctx context
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_Erc20.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(Erc20Approval)
-							if err := _Erc20.contract.UnpackLog(ev, "Approval", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(Erc20Approval)
+					if err := _Erc20.contract.UnpackLog(ev, "Approval", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return
@@ -550,7 +514,7 @@ type Erc20Transfer struct {
 	From  common.Address
 	To    common.Address
 	Value *big.Int
-	Log   thorest.EventLog
+	Log   *thorest.EventLog
 }
 
 type Erc20TransferCriteria struct {
@@ -600,14 +564,6 @@ func (_Erc20 *Erc20) FilterTransfer(criteria []Erc20TransferCriteria, filters *t
 	logs, err := _Erc20.thor.FilterEvents(criteriaSet, filters)
 	if err != nil {
 		return nil, err
-	}
-
-	inputs := _Erc20.contract.ABI.Events["Transfer"].Inputs
-	var indexed abi.Arguments
-	for _, arg := range inputs {
-		if arg.Indexed {
-			indexed = append(indexed, arg)
-		}
 	}
 
 	events := make([]Erc20Transfer, len(logs))
@@ -670,42 +626,14 @@ func (_Erc20 *Erc20) WatchTransfer(criteria []Erc20TransferCriteria, ctx context
 				if err != nil {
 					continue
 				}
-				for _, tx := range block.Transactions {
-					for index, outputs := range tx.Outputs {
-						for _, event := range outputs.Events {
-							matches := false
-							for _, c := range criteriaSet {
-								if c.Matches(event) {
-									matches = true
-									break
-								}
-							}
-							if !matches {
-								continue
-							}
 
-							log := thorest.EventLog{
-								Address: &_Erc20.contract.Address,
-								Topics:  event.Topics,
-								Data:    event.Data,
-								Meta: thorest.LogMeta{
-									BlockID:     block.ID,
-									BlockNumber: block.Number,
-									BlockTime:   block.Timestamp,
-									TxID:        tx.ID,
-									TxOrigin:    tx.Origin,
-									ClauseIndex: int64(index),
-								},
-							}
-
-							ev := new(Erc20Transfer)
-							if err := _Erc20.contract.UnpackLog(ev, "Transfer", log); err != nil {
-								continue
-							}
-							ev.Log = log
-							eventChan <- ev
-						}
+				for _, log := range block.FilteredEvents(criteriaSet) {
+					ev := new(Erc20Transfer)
+					if err := _Erc20.contract.UnpackLog(ev, "Transfer", log); err != nil {
+						continue
 					}
+					ev.Log = log
+					eventChan <- ev
 				}
 			case <-ctx.Done():
 				return

--- a/thorest/accounts.go
+++ b/thorest/accounts.go
@@ -33,8 +33,8 @@ type InspectRequest struct {
 
 type InspectResponse struct {
 	Data      hexutil.Bytes `json:"data"`
-	Events    []Event       `json:"events"`
-	Transfers []Transfer    `json:"transfers"`
+	Events    []*Event      `json:"events"`
+	Transfers []*Transfer   `json:"transfers"`
 	GasUsed   uint64        `json:"gasUsed"`
 	Reverted  bool          `json:"reverted"`
 	VmError   string        `json:"vmError"`

--- a/thorest/blocks.go
+++ b/thorest/blocks.go
@@ -58,23 +58,67 @@ type BlockTransaction struct {
 }
 
 type ExpandedBlock struct {
-	Number       int64              `json:"number"`
-	ID           common.Hash        `json:"id"`
-	Size         int64              `json:"size"`
-	ParentID     common.Hash        `json:"parentID"`
-	Timestamp    int64              `json:"timestamp"`
-	GasLimit     int64              `json:"gasLimit"`
-	Beneficiary  common.Address     `json:"beneficiary"`
-	GasUsed      int64              `json:"gasUsed"`
-	TotalScore   int64              `json:"totalScore"`
-	TxsRoot      common.Hash        `json:"txsRoot"`
-	TxsFeatures  int64              `json:"txsFeatures"`
-	StateRoot    common.Hash        `json:"stateRoot"`
-	ReceiptsRoot common.Hash        `json:"receiptsRoot"`
-	Com          bool               `json:"com"`
-	Signer       common.Address     `json:"signer"`
-	IsTrunk      bool               `json:"isTrunk"`
-	IsFinalized  bool               `json:"isFinalized"`
-	BaseFee      *hexutil.Big       `json:"baseFee"`
-	Transactions []BlockTransaction `json:"transactions"`
+	Number       int64               `json:"number"`
+	ID           common.Hash         `json:"id"`
+	Size         int64               `json:"size"`
+	ParentID     common.Hash         `json:"parentID"`
+	Timestamp    int64               `json:"timestamp"`
+	GasLimit     int64               `json:"gasLimit"`
+	Beneficiary  common.Address      `json:"beneficiary"`
+	GasUsed      int64               `json:"gasUsed"`
+	TotalScore   int64               `json:"totalScore"`
+	TxsRoot      common.Hash         `json:"txsRoot"`
+	TxsFeatures  int64               `json:"txsFeatures"`
+	StateRoot    common.Hash         `json:"stateRoot"`
+	ReceiptsRoot common.Hash         `json:"receiptsRoot"`
+	Com          bool                `json:"com"`
+	Signer       common.Address      `json:"signer"`
+	IsTrunk      bool                `json:"isTrunk"`
+	IsFinalized  bool                `json:"isFinalized"`
+	BaseFee      *hexutil.Big        `json:"baseFee"`
+	Transactions []*BlockTransaction `json:"transactions"`
+}
+
+func (b *ExpandedBlock) Events() []*EventLog {
+	events := make([]*EventLog, 0)
+	for _, transaction := range b.Transactions {
+		for i, output := range transaction.Outputs {
+			for _, ev := range output.Events {
+				ev := &EventLog{
+					Address: ev.Address,
+					Topics:  ev.Topics,
+					Data:    ev.Data,
+					Meta: &LogMeta{
+						BlockID:     b.ID,
+						BlockNumber: b.Number,
+						BlockTime:   b.Timestamp,
+						TxID:        transaction.ID,
+						TxOrigin:    transaction.Origin,
+						ClauseIndex: int64(i),
+					},
+				}
+				events = append(events, ev)
+			}
+		}
+	}
+	return events
+}
+
+func (b *ExpandedBlock) FilteredEvents(criteriaSet []EventCriteria) []*EventLog {
+	relevant := make([]*EventLog, 0)
+
+	for _, ev := range b.Events() {
+		matches := len(criteriaSet) == 0
+		for _, c := range criteriaSet {
+			if c.Matches(ev) {
+				matches = true
+				break
+			}
+		}
+		if matches {
+			relevant = append(relevant, ev)
+		}
+	}
+
+	return relevant
 }

--- a/thorest/client.go
+++ b/thorest/client.go
@@ -200,9 +200,9 @@ func (c *Client) TransactionReceiptAt(id common.Hash, head common.Hash) (*Transa
 }
 
 // FilterEvents fetches the event logs that match the given filter.
-func (c *Client) FilterEvents(criteriaSet []EventCriteria, filters *LogFilters) ([]EventLog, error) {
+func (c *Client) FilterEvents(criteriaSet []EventCriteria, filters *LogFilters) ([]*EventLog, error) {
 	path := "/logs/event"
-	events := make([]EventLog, 0)
+	events := make([]*EventLog, 0)
 	request := eventFilter{
 		Criteria: &criteriaSet,
 	}
@@ -219,9 +219,9 @@ func (c *Client) FilterEvents(criteriaSet []EventCriteria, filters *LogFilters) 
 }
 
 // FilterTransfers fetches the transfer logs that match the given filter.
-func (c *Client) FilterTransfers(criteriaSet []TransferCriteria, filters *LogFilters) ([]TransferLog, error) {
+func (c *Client) FilterTransfers(criteriaSet []TransferCriteria, filters *LogFilters) ([]*TransferLog, error) {
 	path := "/logs/transfer"
-	transfers := make([]TransferLog, 0)
+	transfers := make([]*TransferLog, 0)
 	request := transferFilter{
 		Criteria: &criteriaSet,
 	}

--- a/thorest/logs_event.go
+++ b/thorest/logs_event.go
@@ -9,7 +9,7 @@ type EventLog struct {
 	Address *common.Address `json:"address,omitempty"`
 	Topics  []common.Hash   `json:"topics"`
 	Data    hexutil.Bytes   `json:"data"`
-	Meta    LogMeta         `json:"meta"`
+	Meta    *LogMeta        `json:"meta"`
 }
 
 type eventFilter struct {
@@ -28,8 +28,8 @@ type EventCriteria struct {
 	Topic4  *common.Hash    `json:"topic4,omitempty"`
 }
 
-func (e *EventCriteria) Matches(event Event) bool {
-	if e.Address != nil && *e.Address != event.Address {
+func (e *EventCriteria) Matches(event *EventLog) bool {
+	if e.Address != nil && event.Address != nil && e.Address.Cmp(*event.Address) != 0 {
 		return false
 	}
 

--- a/thorest/logs_events_test.go
+++ b/thorest/logs_events_test.go
@@ -15,19 +15,19 @@ func TestEventCriteria_Matches(t *testing.T) {
 	tests := []struct {
 		name     string
 		criteria EventCriteria
-		event    Event
+		event    *EventLog
 		expected bool
 	}{
 		{
 			name:     "Match on Address only",
 			criteria: EventCriteria{Address: &common.Address{0x1}},
-			event:    Event{Address: common.Address{0x1}, Topics: nil},
+			event:    &EventLog{Address: &common.Address{0x1}, Topics: nil},
 			expected: true,
 		},
 		{
 			name:     "Address mismatch",
 			criteria: EventCriteria{Address: &common.Address{0x1}},
-			event:    Event{Address: common.Address{0x2}, Topics: nil},
+			event:    &EventLog{Address: &common.Address{0x2}, Topics: nil},
 			expected: false,
 		},
 		{
@@ -35,7 +35,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 			criteria: EventCriteria{
 				Topic0: hexToHash("0xabc123"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{
 					common.HexToHash("0xabc123"),
 				},
@@ -47,7 +47,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 			criteria: EventCriteria{
 				Topic0: hexToHash("0xabc123"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{
 					common.HexToHash("0xdef456"),
 				},
@@ -59,7 +59,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 			criteria: EventCriteria{
 				Topic1: hexToHash("0xabc123"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{
 					common.HexToHash("0xabc123"),
 				},
@@ -72,7 +72,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 				Topic0: hexToHash("0xabc123"),
 				Topic1: hexToHash("0xdef456"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{
 					common.HexToHash("0xabc123"),
 					common.HexToHash("0xdef456"),
@@ -87,7 +87,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 				Topic1: hexToHash("0xdef456"),
 				Topic2: hexToHash("0xfed789"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{
 					common.HexToHash("0xabc123"),
 					common.HexToHash("0xdef456"),
@@ -102,8 +102,8 @@ func TestEventCriteria_Matches(t *testing.T) {
 				Topic0:  nil,
 				Topic1:  nil,
 			},
-			event: Event{
-				Address: common.Address{0x1},
+			event: &EventLog{
+				Address: &common.Address{0x1},
 				Topics: []common.Hash{
 					common.HexToHash("0xabc123"),
 				},
@@ -115,7 +115,7 @@ func TestEventCriteria_Matches(t *testing.T) {
 			criteria: EventCriteria{
 				Topic0: hexToHash("0xabc123"),
 			},
-			event: Event{
+			event: &EventLog{
 				Topics: []common.Hash{},
 			},
 			expected: false,

--- a/thorest/logs_transfers.go
+++ b/thorest/logs_transfers.go
@@ -9,7 +9,7 @@ type TransferLog struct {
 	Sender    common.Address `json:"sender"`
 	Recipient common.Address `json:"recipient"`
 	Amount    *hexutil.Big   `json:"amount"`
-	Meta      LogMeta        `json:"meta"`
+	Meta      *LogMeta       `json:"meta"`
 }
 
 type TransferCriteria struct {

--- a/thorest/transactions.go
+++ b/thorest/transactions.go
@@ -54,9 +54,9 @@ type Output struct {
 }
 
 type Event struct {
-	Address common.Address `json:"address"`
-	Topics  []common.Hash  `json:"topics"`
-	Data    hexutil.Bytes  `json:"data"`
+	Address *common.Address `json:"address"`
+	Topics  []common.Hash   `json:"topics"`
+	Data    hexutil.Bytes   `json:"data"`
 }
 
 type ReceiptMeta struct {

--- a/thorgo.go
+++ b/thorgo.go
@@ -43,12 +43,12 @@ func (t *Thor) Transactor(clauses []*tx.Clause) *transactions.Transactor {
 }
 
 // Events sets up a query builder to fetch smart contract solidity events.
-func (t *Thor) Events(criteria []thorest.EventCriteria, filters *thorest.LogFilters) ([]thorest.EventLog, error) {
+func (t *Thor) Events(criteria []thorest.EventCriteria, filters *thorest.LogFilters) ([]*thorest.EventLog, error) {
 	return t.Client.FilterEvents(criteria, filters)
 }
 
 // Transfers sets up a query builder to fetch VET transfers.
-func (t *Thor) Transfers(criteria []thorest.TransferCriteria, filters *thorest.LogFilters) ([]thorest.TransferLog, error) {
+func (t *Thor) Transfers(criteria []thorest.TransferCriteria, filters *thorest.LogFilters) ([]*thorest.TransferLog, error) {
 	return t.Client.FilterTransfers(criteria, filters)
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on changing various structures to use pointers instead of values for `EventLog`, `TransferLog`, and `LogMeta`, enhancing memory efficiency and potentially improving performance. 

### Detailed summary
- Changed `LogMeta` in `logs_transfers.go` to a pointer.
- Updated `Event` struct in `transactions.go` to use a pointer for `Address`.
- Modified `InspectResponse` in `accounts.go` to use slices of pointers for `Events` and `Transfers`.
- Adjusted `EventCriteria` matches method in `logs_event.go` to accept a pointer to `EventLog`.
- Updated methods in `thorgo.go` to return slices of pointers for `EventLog` and `TransferLog`.
- Changed `EventLog` in multiple files to use pointers, including `contract.go`, `client.go`, `params.go`, `authority.go`, `executor.go`, and others.
- Updated test cases in `logs_events_test.go` to reflect changes in `EventLog` handling.
- Added methods in `ExpandedBlock` to return filtered events as pointers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->