### PR TITLE
chore: add a transaction gas buffer option

### DIFF
--- a/transactions/options.go
+++ b/transactions/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	BlockRef             *tx.BlockRef    // BlockRef specifies the block reference.
 	DependsOn            *common.Hash    // DependsOn specifies the transaction that this transaction depends on.
 	ChainTag             *byte           // ChainTag specifies the chain tag.
+	GasBuffer            *uint64         // GasBuffer is the amount of gas to add to an estimation
 }
 
 // OptionsBuilder is a builder for creating transaction options.

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -31,13 +31,14 @@ func TestContractClause(t *testing.T) {
 	assert.False(t, simulation.Reverted())
 
 	// build
-	tx, err := txbuilder.Build(account1Addr, &transactions.Options{})
+	trx, err := txbuilder.Build(account1Addr, &transactions.Options{})
 	assert.NoError(t, err)
+	assert.Equal(t, trx.Type(), tx.TypeDynamicFee)
 
 	// sign
-	signingHash := tx.SigningHash()
+	signingHash := trx.SigningHash()
 	signature, _ := crypto.Sign(signingHash.Bytes(), account1)
-	signedTx := tx.WithSignature(signature)
+	signedTx := trx.WithSignature(signature)
 
 	// send
 	res, err := thorClient.SendTransaction(signedTx)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a `GasBuffer` option to transaction options, enhancing gas estimation for transactions. It also refactors variable names for consistency and updates the `Build` method to accommodate the new `GasBuffer` functionality.

### Detailed summary
- Added `GasBuffer` field to `Options` struct in `transactions/options.go`.
- Changed variable name from `tx` to `trx` in `transactor_test.go` for consistency.
- Updated `Build` method in `Transactor` to include `GasBuffer` in gas calculations.
- Defined a constant `GasBuffer` with a default value of `20,000`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional gas buffer when estimating transaction gas. Users can now specify a custom gas buffer or rely on the default value.
* **Documentation**
  * Updated method documentation to describe the new gas buffer option and its default behavior.
* **Tests**
  * Improved transaction tests to verify transaction type and clarified variable naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->